### PR TITLE
libdicom: 1.0.5 -> 1.2.0 ; fix build for pkgsLLVM

### DIFF
--- a/pkgs/by-name/li/libdicom/package.nix
+++ b/pkgs/by-name/li/libdicom/package.nix
@@ -1,8 +1,8 @@
 {
   lib,
   stdenv,
+  buildPackages,
   fetchFromGitHub,
-  fetchpatch,
   uthash,
   meson,
   ninja,
@@ -12,32 +12,25 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libdicom";
-  version = "1.0.5";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "ImagingDataCommons";
     repo = "libdicom";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-9n0Gp9+fmTM/shgWC8zpwt1pic9BrvDubOt7f+ZDMeE=";
+    sha256 = "sha256-YaCN2QuL+yGfSYw3/wxgu9hut98UYa5tMTzTs2NGP1A=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "CVE-2024-24793.CVE-2024-24794.patch";
-      url = "https://github.com/ImagingDataCommons/libdicom/commit/3661aa4cdbe9c39f67d38ae87520f9e3ed50ab16.patch";
-      excludes = [ "CHANGELOG.md" ];
-      hash = "sha256-/KTp0nKYk6jX4phNHY+nzjEptUBHKM2JkOftS5vHsEw=";
-    })
-  ];
-
-  buildInputs = [ uthash ];
+  buildInputs = [ uthash ] ++ lib.optionals (finalAttrs.finalPackage.doCheck) [ check ];
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
-  ]
-  ++ lib.optionals (finalAttrs.finalPackage.doCheck) [ check ];
+  ];
+
+  # fix build for pkgsLLVM. Related: https://github.com/NixOS/nixpkgs/issues/265121
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   mesonBuildType = "release";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
